### PR TITLE
chore: updated to 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.4-cli
+FROM php:8-cli
 
-LABEL version="7.4"
+LABEL version="8"
 LABEL repository="https://github.com/StephaneBour/actions-php-lint"
 LABEL homepage="https://github.com/StephaneBour/actions-php-lint"
 LABEL maintainer="Stéphane Bour <stephane.bour@gmail.com>"


### PR DESCRIPTION
feat: Support for PHP 8
Probably? My machine wouldn't let me test. I hate WSL2.
Verified the docker image for php:8-cli exists and changed 7.4 to 8.