### PR TITLE
Updating Dockerfile to PHP version 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.2-cli
+FROM php:8.3-cli
 
-LABEL version="8.2"
+LABEL version="8.3"
 LABEL repository="https://github.com/StephaneBour/actions-php-lint"
 LABEL homepage="https://github.com/StephaneBour/actions-php-lint"
 LABEL maintainer="Stéphane Bour <stephane.bour@gmail.com>"


### PR DESCRIPTION
## Changes
- Updating Dockerfile PHP version to 8.3.

## Notes
- Pointed at the 8.2 branch, as there doesn't seem to be a master, main or develop branch to point this at.